### PR TITLE
Add support for Tinker's Construct Smeltery

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -39,6 +39,7 @@
 			<available file="${mcpsrc.dir}/buildcraft" type="dir"/>
 			<available file="${mcpsrc.dir}/ic2" type="dir"/>
 			<!--<available file="${mcpsrc.dir}/thermalexpansion" type="dir"/>-->
+			<available file="${mcpsrc.dir}/tconstruct" type="dir"/>
 		</and>
 	</condition>
 	
@@ -67,6 +68,9 @@
 		
 		<echo message="Downloading AppEng API..." />
 		<get src="http://ae-mod.info/releases/appeng-rv13-c-mc162.jar" dest="${download.dir}/appeng.zip"/>
+		
+		<echo message="Downloading TConstruct Library..." />
+		<get src="https://dl.dropboxusercontent.com/u/42769935/Tinker_1.6.2/TConstruct_Library_1.6.4_5.0.0.zip" dest="${download.dir}/TConstruct-library.zip" />
 	</target>
 
 	<target name="extract-dependencies" depends="setup-forge,get-dependencies" unless="${have-apis}">
@@ -92,6 +96,10 @@
 		<delete file="${download.dir}/appeng" />
 		<unzip src="${download.dir}/appeng_api.zip" dest="${download.dir}" />
 		<move file="${download.dir}/appeng" todir="${mcpsrc.dir}" />
+		
+		<echo message="Extracting TConstruct Library... " />
+		<unzip src="${download.dir}/TConstruct-library.zip" dest="${download.dir}" />
+		<move file="${download.dir}/tconstruct" todir="${mcpsrc.dir}" />
 	</target>
 
 
@@ -175,6 +183,7 @@
 		<delete dir="${mcp.dir}/reobf/minecraft/ic2"/>
 		<delete dir="${mcp.dir}/reobf/minecraft/powercrystals/core"/>
 		<delete dir="${mcp.dir}/reobf/minecraft/appeng"/>
+		<delete dir="${mcp.dir}/reobf/minecraft/tconstruct"/>
 		
 		<copy todir="${classes.dir}">
 			<fileset dir="${mcp.dir}/reobf/minecraft"/>

--- a/src/powercrystals/netherores/NetherOresCore.java
+++ b/src/powercrystals/netherores/NetherOresCore.java
@@ -70,6 +70,7 @@ public class NetherOresCore extends BaseMod
 	public static Property enablePulverizerRecipes;
 	public static Property enableInductionSmelterRecipes;
 	public static Property enableGrinderRecipes;
+	public static Property enableSmelteryRecipes;
 	public static Property forceOreSpawn;
 	public static Property worldGenAllDimensions;
 	public static Property enableHellQuartz;
@@ -124,7 +125,7 @@ public class NetherOresCore extends BaseMod
 	@EventHandler
 	public void postInit(FMLPostInitializationEvent e)
 	{
-		if(enableStandardFurnaceRecipes.getBoolean(true) || enableInductionSmelterRecipes.getBoolean(true))
+		if(enableStandardFurnaceRecipes.getBoolean(true) || enableInductionSmelterRecipes.getBoolean(true) || enableSmelteryRecipes.getBoolean(true))
 		{
 			Ores.coal.registerSmelting(new ItemStack(Block.oreCoal));
 			Ores.diamond.registerSmelting(new ItemStack(Block.oreDiamond));
@@ -226,6 +227,8 @@ public class NetherOresCore extends BaseMod
 		enableInductionSmelterRecipes.comment = "Set this to false to remove the TE Induction Smelter recipes (ie, nether iron ore -> 2x normal iron ore).";
 		enableGrinderRecipes = c.get(Configuration.CATEGORY_GENERAL, "EnableGrinderRecipes", true);
 		enableGrinderRecipes.comment = "Set this to false to remove the AE Grind Stone recipes (ie, nether iron ore -> 4x iron dust).";
+		enableSmelteryRecipes = c.get(Configuration.CATEGORY_GENERAL, "EnableSmelteryRecipes", true);
+		enableSmelteryRecipes.comment = "Set this to false to remove the TConstruct Smeltery recipes (ie, nether iron ore -> 576mb liquid iron).";
 		forceOreSpawn = c.get(Configuration.CATEGORY_GENERAL, "ForceOreSpawn", false);
 		forceOreSpawn.comment = "If true, will spawn nether ores regardless of if a furnace or macerator recipe was found. If false, at least one of those two must be found to spawn the ore.";
 		enableHellfish = c.get(Configuration.CATEGORY_GENERAL, "HellfishEnable", true);

--- a/src/powercrystals/netherores/ores/Ores.java
+++ b/src/powercrystals/netherores/ores/Ores.java
@@ -15,7 +15,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
 import net.minecraftforge.common.Configuration;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
+import tconstruct.library.crafting.Smeltery;
 
 public enum Ores
 {
@@ -154,6 +156,18 @@ public enum Ores
 			CraftingManagers.smelterManager.addRecipe(320, new ItemStack(NetherOresCore.getOreBlock(_blockIndex), 1, _metadata), new ItemStack(Block.sand), smeltToReg, ItemRegistry.getItem("slagRich", 1), 10, false);
 			CraftingManagers.smelterManager.addRecipe(400, new ItemStack(NetherOresCore.getOreBlock(_blockIndex), 1, _metadata), ItemRegistry.getItem("slagRich", 1), smeltToRich, ItemRegistry.getItem("slag", 1), 80, false);
 		}//*/
+
+		if(NetherOresCore.enableSmelteryRecipes.getBoolean(true) && Loader.isModLoaded("TConstruct"))
+		{
+			FluidStack meltTo = Smeltery.getSmelteryResult(smeltStack.copy());
+
+			if(meltTo != null)
+			{
+				meltTo = meltTo.copy();
+				meltTo.amount *= _smeltCount;
+				Smeltery.addMelting(NetherOresCore.getOreBlock(_blockIndex), _metadata, Smeltery.getLiquifyTemperature(smeltStack.copy()), meltTo);
+			}
+		}
 	}
 	
 	public void registerMacerator(ItemStack maceStack)


### PR DESCRIPTION
This change allows nether ores to be used in the Smeltery from Tinker's Construct.  It is patterned after existing smelting/macerating support and includes the corresponding changes to the buildfile and configuration properties.