### PR TITLE
Add support for Applied Energistics Grind Stone

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -64,6 +64,9 @@
 		
 		<echo message="Downloading BuildCraft API..." />
 		<get src="https://github.com/BuildCraft/BuildCraft/archive/3e13bbb166568624cc918f8a9f916fa2062f6c37.zip" dest="${download.dir}/Buildcraft-master.zip"/>
+		
+		<echo message="Downloading AppEng API..." />
+		<get src="http://ae-mod.info/releases/appeng-rv13-c-mc162.jar" dest="${download.dir}/appeng.zip"/>
 	</target>
 
 	<target name="extract-dependencies" depends="setup-forge,get-dependencies" unless="${have-apis}">
@@ -83,6 +86,12 @@
 		<echo message="Extracting IC2 API... " />
 		<unzip src="${download.dir}/industrialcraft-2-api.zip" dest="${download.dir}" />
 		<move file="${download.dir}/ic2" todir="${mcpsrc.dir}" />
+		
+		<echo message="Extracting AppEng API... " />
+		<unzip src="${download.dir}/appeng.zip" dest="${download.dir}" />
+		<delete file="${download.dir}/appeng" />
+		<unzip src="${download.dir}/appeng_api.zip" dest="${download.dir}" />
+		<move file="${download.dir}/appeng" todir="${mcpsrc.dir}" />
 	</target>
 
 
@@ -165,6 +174,7 @@
 		<delete dir="${mcp.dir}/reobf/minecraft/buildcraft"/>
 		<delete dir="${mcp.dir}/reobf/minecraft/ic2"/>
 		<delete dir="${mcp.dir}/reobf/minecraft/powercrystals/core"/>
+		<delete dir="${mcp.dir}/reobf/minecraft/appeng"/>
 		
 		<copy todir="${classes.dir}">
 			<fileset dir="${mcp.dir}/reobf/minecraft"/>

--- a/src/powercrystals/netherores/NetherOresCore.java
+++ b/src/powercrystals/netherores/NetherOresCore.java
@@ -69,6 +69,7 @@ public class NetherOresCore extends BaseMod
 	public static Property enableMaceratorRecipes;
 	public static Property enablePulverizerRecipes;
 	public static Property enableInductionSmelterRecipes;
+	public static Property enableGrinderRecipes;
 	public static Property forceOreSpawn;
 	public static Property worldGenAllDimensions;
 	public static Property enableHellQuartz;
@@ -133,7 +134,7 @@ public class NetherOresCore extends BaseMod
 			Ores.redstone.registerSmelting(new ItemStack(Block.oreRedstone));
 			Ores.emerald.registerSmelting(new ItemStack(Block.oreEmerald));
 		}
-		if(enableMaceratorRecipes.getBoolean(true) || enablePulverizerRecipes.getBoolean(true))
+		if(enableMaceratorRecipes.getBoolean(true) || enablePulverizerRecipes.getBoolean(true) || enableGrinderRecipes.getBoolean(true))
 		{
 			Ores.diamond.registerMacerator(new ItemStack(Item.diamond));
 			Ores.coal.registerMacerator(new ItemStack(Item.coal));
@@ -223,6 +224,8 @@ public class NetherOresCore extends BaseMod
 		enablePulverizerRecipes.comment = "Set this to false to remove the TE Pulvierzer recipes (ie, nether iron ore -> 4x iron dust).";
 		enableInductionSmelterRecipes = c.get(Configuration.CATEGORY_GENERAL, "EnableInductionSmelterRecipes", true);
 		enableInductionSmelterRecipes.comment = "Set this to false to remove the TE Induction Smelter recipes (ie, nether iron ore -> 2x normal iron ore).";
+		enableGrinderRecipes = c.get(Configuration.CATEGORY_GENERAL, "EnableGrinderRecipes", true);
+		enableGrinderRecipes.comment = "Set this to false to remove the AE Grind Stone recipes (ie, nether iron ore -> 4x iron dust).";
 		forceOreSpawn = c.get(Configuration.CATEGORY_GENERAL, "ForceOreSpawn", false);
 		forceOreSpawn.comment = "If true, will spawn nether ores regardless of if a furnace or macerator recipe was found. If false, at least one of those two must be found to spawn the ore.";
 		enableHellfish = c.get(Configuration.CATEGORY_GENERAL, "HellfishEnable", true);

--- a/src/powercrystals/netherores/ores/Ores.java
+++ b/src/powercrystals/netherores/ores/Ores.java
@@ -1,5 +1,9 @@
 package powercrystals.netherores.ores;
 
+import appeng.api.IAppEngGrinderRecipe;
+import java.util.List;
+import appeng.api.IGrinderRecipeManager;
+import appeng.api.Util;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 
@@ -200,6 +204,33 @@ public enum Ores
 		   
 			CraftingManagers.pulverizerManager.addRecipe(400, new ItemStack(NetherOresCore.getOreBlock(_blockIndex), 1, _metadata), pulvPriTo, pulvSecTo, 15, false);
 		}//*/
+
+		if(NetherOresCore.enableGrinderRecipes.getBoolean(true) && Loader.isModLoaded("AppliedEnergistics"))
+		{
+			ItemStack maceTo = maceStack.copy();
+			maceTo.stackSize = _maceCount;
+
+			IGrinderRecipeManager grinder = Util.getGrinderRecipeManage();
+			boolean added = false;
+
+			for(ItemStack ore : OreDictionary.getOres(_oreName))
+			{
+				IAppEngGrinderRecipe recipe = grinder.getRecipeForInput(ore);
+
+				if(recipe != null)
+				{
+					grinder.addRecipe(new ItemStack(NetherOresCore.getOreBlock(_blockIndex), 1, _metadata), maceTo, recipe.getEnergyCost());
+					added = true;
+					break;
+				}
+			}
+
+			// if there's no overworld recipe to get the energy cost from, default to 8 turns
+			if(!added)
+			{
+				grinder.addRecipe(new ItemStack(NetherOresCore.getOreBlock(_blockIndex), 1, _metadata), maceTo, 8);
+			}
+		}
 	}
 	
 	public void loadConfig(Configuration c)


### PR DESCRIPTION
This change allows nether ores to be used with the Grind Stone from Applied Energistics. It is patterned after existing smelting/macerating support and includes the corresponding changes to the buildfile and configuration properties.
