### PR TITLE
The "Diamands are forever" update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Ores in the Nether! Coal, diamond, gold, iron, lapis, redstone, tin, copper, emerald, silver, lead, uranium, and nikolite. Non-vanilla ores only spawn if a mod that uses them exists. All nether ores turn into their surface counterparts in a furnace - some (like redstone or coal) may need to be smacked with a pick or macerated to be made useful.

--- a/src/powercrystals/netherores/ores/BlockNetherOverrideOre.java
+++ b/src/powercrystals/netherores/ores/BlockNetherOverrideOre.java
@@ -46,6 +46,18 @@ public class BlockNetherOverrideOre extends Block implements INetherOre
 				(ItemBlock)Item.getItemFromBlock(_override), this, "field_150939_a");
 	}
 
+	public void setOverride()
+	{
+		// override this.
+		// Ex. Blocks.quartz_ore = this;
+	}
+	
+	public void resetOverride()
+	{
+		// override this.
+		// Ex. Blocks.quartz_ore = _override;
+	}
+	
 	@Override
 	public boolean isAssociatedBlock(Block block)
 	{
@@ -107,7 +119,10 @@ public class BlockNetherOverrideOre extends Block implements INetherOre
 	@Override
 	public int getExpDrop(IBlockAccess world, int a, int b)
 	{
-		return _override.getExpDrop(world, a, b);
+		resetOverride();
+		int exp = _override.getExpDrop(world, a, b);
+		setOverride();
+		return exp;
 	}
 
 	@Override
@@ -400,7 +415,9 @@ public class BlockNetherOverrideOre extends Block implements INetherOre
 		if (calling.get() == Boolean.TRUE)
 			return;
 		calling.set(Boolean.TRUE);
+		resetOverride();
 		_override.harvestBlock(world, player, p_149636_3_, p_149636_4_, p_149636_5_, p_149636_6_);
+		setOverride();
 		calling.set(null);
 	}
 
@@ -462,7 +479,9 @@ public class BlockNetherOverrideOre extends Block implements INetherOre
 		explode.set(false);
 		willAnger.set(NetherOresCore.enableMobsAngerPigmen.getBoolean(true) ||
 				explosion == null || !(explosion.getExplosivePlacedBy() instanceof EntityLiving));
+		resetOverride();
 		_override.onBlockExploded(world, x, y, z, explosion);
+		setOverride();
 		willAnger.set(true);
 		explode.set(true);
 		if (NetherOresCore.enableExplosionChainReactions.getBoolean(true))


### PR DESCRIPTION
Not sure if you take pull requests, but I made this for my self, and I think it's worth it for more people. It also looked like you once had started it.

Diamonds, Emeralds, Redstone, Coal, Nether Quartz and anything else that normally drops as gems instead of ore without silk touch will now do so in the nether also. Configurable. Can be turned off either globally or per ore.
The number of items those ores drops are about twice of what they drop in the overworld. This is also configurable.
Ores that drops items also drops exp as they do in the overworld.
Made the range at when Pigman gets mad at you for mining there ore configurable.
